### PR TITLE
Can only use integers when calling Marker::setPosition($lat, $long)

### DIFF
--- a/Model/Marker.php
+++ b/Model/Marker.php
@@ -69,17 +69,17 @@ class Marker extends AbstractAsset
      * Available prototype:
      * 
      * public function setPosition(Ivory\GoogleMapBundle\Model\Coordinate $position)
-     * public function setPosition(integer $latitude, integer $longitude, boolean $noWrap = true)
+     * public function setPosition(double $latitude, double $longitude, boolean $noWrap = true)
      */
     public function setPosition()
     {
         $args = func_get_args();
-        
-        if(isset($args[0]) && is_int($args[0]) && isset($args[1]) && is_int($args[1]))
+
+        if(isset($args[0]) && is_numeric($args[0]) && isset($args[1]) && is_numeric($args[1]))
         {
             $this->position->setLatitude($args[0]);
             $this->position->setLongitude($args[1]);
-            
+
             if(isset($args[2]) && is_bool($args[2]))
                 $this->position->setNoWrap($args[2]);
         }


### PR DESCRIPTION
I think it's better to accept all numeric values, since the underlying Coordinate class taken doubles for its position.

---

Changed method signature of Marker::setPosition to (double, double, bool).

In commit cc0aec5e38fe200dbe9059fa652530125c35724b the Marker::setPosition method was altered to take a Coordinate _or_ a longitude & latitude as integer.

This commit changes the longitude & latitude to be any numeric value to allow higher precision long/lat, since the position of the Coordinate class already accepts doubles for its position.
