### PR TITLE
Make http adapter optional (2.1 BC)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1061,7 +1061,7 @@ class Configuration implements ConfigurationInterface
     {
         $node
             ->children()
-                ->arrayNode('directions')->addDefaultsIfNotSet()
+                ->arrayNode('directions')
                     ->children()
                         ->scalarNode('class')->end()
                         ->scalarNode('adapter')
@@ -1110,7 +1110,7 @@ class Configuration implements ConfigurationInterface
     {
         $node
             ->children()
-                ->arrayNode('distance_matrix')->addDefaultsIfNotSet()
+                ->arrayNode('distance_matrix')
                     ->children()
                         ->scalarNode('class')->end()
                         ->scalarNode('adapter')

--- a/DependencyInjection/IvoryGoogleMapExtension.php
+++ b/DependencyInjection/IvoryGoogleMapExtension.php
@@ -114,10 +114,16 @@ class IvoryGoogleMapExtension extends Extension
         $this->loadGeocoder($config, $container);
         $this->loadGeocoderFakeRequest($config, $container);
         $this->loadGeocoderRequest($config, $container);
-        $this->loadDirections($config, $container);
-        $this->loadDirectionsRequest($config, $container);
-        $this->loadDistanceMatrix($config, $container);
-        $this->loadDistanceMatrixRequest($config, $container);
+
+        if (isset($config['directions'])) {
+            $this->loadDirections($config, $container);
+            $this->loadDirectionsRequest($config, $container);
+        }
+
+        if (isset($config['distance_matrix'])) {
+            $this->loadDistanceMatrix($config, $container);
+            $this->loadDistanceMatrixRequest($config, $container);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR disables the distance_matrix and direction sections by default, so there is no default dependency on http adapter.
Default section settings can be enabled by configuring the directions or distance_matrix parameters.
