### PR TITLE
Fix composer error InvalidArgumentException

### DIFF
--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -5,7 +5,7 @@
 Require the bundle in your composer.json file:
 
 ```sh
-composer require egeloen/google-map-bundle: ~2.1
+composer require egeloen/google-map-bundle ~2.1
 ```
 
 If you want to use Geocoding stuff, you will need [Geocoder](http://github.com/willdurand/Geocoder):


### PR DESCRIPTION
Fix composer error InvalidArgumentException: Could not find package ~2.1 at any version for your minimum-stability (stable). Check the package spelling or your minimum-stability