### PR TITLE
API Key support and fix for Sensor Warning

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -192,6 +192,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('width')->end()
                         ->scalarNode('height')->end()
                         ->scalarNode('language')->end()
+                        ->scalarNode('api_key')->end()
                         ->arrayNode('map_options')
                             ->useAttributeAsKey('map_options')
                             ->prototype('scalar')->end()

--- a/DependencyInjection/IvoryGoogleMapExtension.php
+++ b/DependencyInjection/IvoryGoogleMapExtension.php
@@ -242,6 +242,10 @@ class IvoryGoogleMapExtension extends Extension
             $builderDefinition->addMethodCall('setLanguage', array($config['map']['language']));
         }
 
+        if (isset($config['map']['api_key'])) {
+            $builderDefinition->addMethodCall('setApiKey', array($config['map']['api_key']));
+        }
+
         $mapOptions = array();
 
         if (isset($config['map']['type'])) {

--- a/Model/MapBuilder.php
+++ b/Model/MapBuilder.php
@@ -57,6 +57,9 @@ class MapBuilder extends AbstractBuilder
     /** @var array */
     protected $stylesheetOptions;
 
+    /** @var string */
+    protected $apiKey;
+
     /**
      * Creates a map builder.
      *
@@ -382,6 +385,24 @@ class MapBuilder extends AbstractBuilder
     }
 
     /**
+     * Gets the Browser API Key
+     * @return string
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * Sets the Browser API Key
+     * @param string $apiKey
+     */
+    public function setApiKey($apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function reset()
@@ -396,6 +417,7 @@ class MapBuilder extends AbstractBuilder
         $this->bound = array();
         $this->mapOptions = array();
         $this->stylesheetOptions = array();
+        $this->apiKey = null;
 
         return $this;
     }
@@ -454,6 +476,10 @@ class MapBuilder extends AbstractBuilder
 
         if (!empty($this->stylesheetOptions)) {
             $map->setStylesheetOptions($this->stylesheetOptions);
+        }
+
+        if ($this->apiKey !== null) {
+            $map->setApiKey($this->apiKey);
         }
 
         return $map;

--- a/Resources/doc/usage/map.md
+++ b/Resources/doc/usage/map.md
@@ -80,6 +80,9 @@ ivory_google_map:
 
         # google map Api language, default en
         language: en
+
+        # google map Browser Api Key
+        api_key: ~
 ```
 
 ``` php


### PR DESCRIPTION
Add API Key support and Address Google Maps warnings
Google Maps API warning: NoApiKeys https://developers.google.com/maps/documentation/javascript/error-messages#no-api-keys
Google Maps API warning: SensorNotRequired https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required

Addresses #114 

Depends on https://github.com/egeloen/ivory-google-map/pull/129