### PR TITLE
Flip composer require command for guzzle and httpplug-bundle

### DIFF
--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -35,8 +35,8 @@ let's install them to ease our life:
 
 ``` bash
 $ composer require egeloen/serializer-bundle
-$ composer require php-http/httplug-bundle
 $ composer require php-http/guzzle6-adapter
+$ composer require php-http/httplug-bundle
 ```
 
 Here, I have chosen to use [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) but since Httplug supports the 


### PR DESCRIPTION
Flip composer require command for guzzle and httpplug-bundle to avoid composer refuse installation of httpplug-bundle due to missing requirement to php-http/client-implementation as there is no release available. 
php-http/client-implementation is a virtual package and in the installation doc is provided by the guzzle6-adapter.