### PR TITLE
Update RegisterFormResourcePass twig template

### DIFF
--- a/DependencyInjection/Compiler/RegisterFormResourcePass.php
+++ b/DependencyInjection/Compiler/RegisterFormResourcePass.php
@@ -38,7 +38,7 @@ class RegisterFormResourcePass implements CompilerPassInterface
             $container->setParameter(
                 $parameter,
                 array_merge(
-                    ['IvoryGoogleMapBundle:Form:place_autocomplete_widget.html.twig'],
+                    ['@IvoryGoogleMap/Form/place_autocomplete_widget.html.twig'],
                     $container->getParameter($parameter)
                 )
             );


### PR DESCRIPTION
fix `Unable to find template "IvoryGoogleMapBundle:Form:place_autocomplete_widget.html.twig"` when using PlaceAutocompleteType

